### PR TITLE
Adopt gaushits

### DIFF
--- a/sbnci/Modules/PFPValidation/pfpvalidation.fcl
+++ b/sbnci/Modules/PFPValidation/pfpvalidation.fcl
@@ -5,7 +5,7 @@ sbnd_pfpslicevalidation_ci:
     module_type:              PFPSliceValidationCI
     GenieGenModuleLabel:      "generator"
     PFParticleLabels:         ["pandora"]
-    HitLabel:                 "linecluster"
+    HitLabel:                 "gaushit"
     UseBeamSpillXCorrection:  true
 }
 
@@ -14,7 +14,7 @@ sbnd_pfpvalidation_ci:
     module_type:    PFPValidationCI
     LArGeantLabel:  "largeant"
     PFPLabels:      ["pandora"]
-    HitLabel:       "linecluster"
+    HitLabel:       "gaushit"
 }
 
 END_PROLOG

--- a/sbnci/Modules/RecoEff/recoeff.fcl
+++ b/sbnci/Modules/RecoEff/recoeff.fcl
@@ -8,7 +8,7 @@ sbnd_recoeff_ci:
     TrackModuleLabel:         	"pandoraTrack"
     ShowerModuleLabel:        	"pandoraShower"
     PFParticleModuleLabel:    	"pandora"
-    HitsModuleLabel:          	"linecluster"
+    HitsModuleLabel:          	"gaushit"
 
     ## Fiducial volume cuts from edges   
 


### PR DESCRIPTION
[PR #84](https://github.com/SBNSoftware/sbndcode/pull/84) in sbndcode changed the pandora input to hits from the `gaushit` module label in place of `linecluster`. This PR reflects that change in the analysis fcls.