### PR TITLE
Add functionality to allow the plot normalisation to be turned on/off from the cfg file.

### DIFF
--- a/sbnci/PlottingScripts/CompareDataDistributions.C
+++ b/sbnci/PlottingScripts/CompareDataDistributions.C
@@ -234,7 +234,7 @@ map<string, vector<float>> thresholdmap(ifstream &infile){
     return mapping;
 }
 
-void CompareDataDistributions(TString gCurVersion="v07_06_00", TString gRefVersion="v07_00_00"){
+void CompareDataDistributions(TString gCurVersion="v07_06_00", TString gRefVersion="v07_00_00", const bool useNormalised = true){
 
 //   TString ref_xrootd_path=gSystem->Getenv("ref_dunetpc_ana_hist_xrootd_path");
 
@@ -326,13 +326,11 @@ void CompareDataDistributions(TString gCurVersion="v07_06_00", TString gRefVersi
               hRef = (TH1D*)RefFile->Get(Form("%s/%s", s_branch_names.Data(), s_histo_names.Data()));
               hCur = (TH1D*)CurFile->Get(Form("%s/%s", s_branch_names.Data(), s_histo_names.Data()));
 
-              if (hRef->Integral() > 0 && hCur->Integral() > 0) {
+              if (hRef->Integral() > 0 && hCur->Integral() > 0 && useNormalised)
                   hCur->Scale((hRef->Integral()+hRef->GetBinContent(0)+hRef->GetBinContent(hRef->GetNbinsX()+1))/(hCur->Integral()+hCur->GetBinContent(0)+hCur->GetBinContent(hCur->GetNbinsX()+1)));
-
-                  double maxext = getMax(hRef, hCur);
-                  hRef->SetMaximum(maxext);
-
-              }
+	      
+	      double maxext = getMax(hRef, hCur);
+	      hRef->SetMaximum(maxext);
           }
           else{
 

--- a/sbnci/PlottingScripts/CompareDataDistributions.C
+++ b/sbnci/PlottingScripts/CompareDataDistributions.C
@@ -326,7 +326,7 @@ void CompareDataDistributions(TString gCurVersion="v07_06_00", TString gRefVersi
               hRef = (TH1D*)RefFile->Get(Form("%s/%s", s_branch_names.Data(), s_histo_names.Data()));
               hCur = (TH1D*)CurFile->Get(Form("%s/%s", s_branch_names.Data(), s_histo_names.Data()));
 
-              if (hRef->Integral() > 0 && hCur->Integral() > 0 && useNormalised)
+              if (useNormalised && hRef->Integral() > 0 && hCur->Integral() > 0)
                   hCur->Scale((hRef->Integral()+hRef->GetBinContent(0)+hRef->GetBinContent(hRef->GetNbinsX()+1))/(hCur->Integral()+hCur->GetBinContent(0)+hCur->GetBinContent(hCur->GetNbinsX()+1)));
 	      
 	      double maxext = getMax(hRef, hCur);

--- a/sbnci/scripts/pfpslicevalidation.sh
+++ b/sbnci/scripts/pfpslicevalidation.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-## Allows for different naming structure in cfg file
+## Introduce environment variables specific to this validation
 export ref_sbndcode_ana_hist=${ref_pfpslice_hist}
+export normalise_plots=${normalise_plots_pfpslice}
 
 ## Name of plotting script. This should be the only line that needs changing for other CI chains.
 plotScript="$SBNCI_DIR/scripts/sbnciplot_pfpslicevalidation.C"

--- a/sbnci/scripts/pfpvalidation.sh
+++ b/sbnci/scripts/pfpvalidation.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-## Allows for different naming structure in cfg file
+## Introduce environment variables specific to this validation
 export ref_sbndcode_ana_hist=${ref_pfp_hist}
+export normalise_plots=${normalise_plots_pfp}
 
 ## Name of plotting script. This should be the only line that needs changing for other CI chains.
 plotScript="$SBNCI_DIR/scripts/sbnciplot_pfpvalidation.C"

--- a/sbnci/scripts/recoeff.sh
+++ b/sbnci/scripts/recoeff.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Allows for different naming structure in cfg file
+## Introduce environment variables specific to this validation
 export ref_sbndcode_ana_hist=${ref_recoeff_hist}
+export normalise_plots=${normalise_plots_recoeff}
 
 ## Name of plotting script. This should be the only line that needs changing for other CI chains.
 plotScript="$SBNCI_DIR/scripts/sbnciplot_recoeff.C"

--- a/sbnci/scripts/sbnciplots.sh
+++ b/sbnci/scripts/sbnciplots.sh
@@ -31,4 +31,4 @@ ln -v ci_validation_histos.root ci_validation_histos_${SBNDCODE_VERSION}.root
 
 ls -lh
 
-root -l -b -q $comparisonScript\(\"${SBNDCODE_VERSION}\",\"${ref_sbndcode_version}\",${normalise_plots}\)
+root -l -b -q $comparisonScript\(\"${SBNDCODE_VERSION}\",\"${ref_sbndcode_version}\",${normalise_plots:-false}\)

--- a/sbnci/scripts/sbnciplots.sh
+++ b/sbnci/scripts/sbnciplots.sh
@@ -9,6 +9,7 @@ plotScript=${1}
 echo "ref_sbndcode_ana_hist: ${ref_sbndcode_ana_hist}"
 export ref_sbndcode_ana_hist_xrootd_path=$(echo ${ref_sbndcode_ana_hist} | sed 's#/pnfs/#root://fndca1.fnal.gov:1094/pnfs/fnal.gov/usr/#g')
 echo "ref_sbndcode_ana_hist_xrootd_path: ${ref_sbndcode_ana_hist_xrootd_path}"
+echo "normalise_plots: ${normalise_plots}"
 
 echo "ref_sbndcode_version: ${ref_sbndcode_version}"
 echo xrdcp -s ${ref_sbndcode_ana_hist_xrootd_path} $(basename ${ref_sbndcode_ana_hist_xrootd_path})
@@ -30,4 +31,4 @@ ln -v ci_validation_histos.root ci_validation_histos_${SBNDCODE_VERSION}.root
 
 ls -lh
 
-root -l -b -q $comparisonScript\(\"${SBNDCODE_VERSION}\",\"${ref_sbndcode_version}\"\)
+root -l -b -q $comparisonScript\(\"${SBNDCODE_VERSION}\",\"${ref_sbndcode_version}\",${normalise_plots}\)

--- a/sbnci/scripts/showervalidation.sh
+++ b/sbnci/scripts/showervalidation.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Allows for different naming structure in cfg file
+## Introduce environment variables specific to this validation
 export ref_sbndcode_ana_hist=${ref_showervalidation_hist}
+export normalise_plots=${normalise_plots_showervalidation}
 
 ## Name of plotting script. This should be the only line that needs changing for other CI chains.
 plotScript="$SBNCI_DIR/scripts/sbnciplot_showervalidation.C"


### PR DESCRIPTION
The `CompareDataDistributions.C` script executes the joint plotting and comparison of the new histograms to the reference histograms. Part of this approach is to scale the histograms based on their number of entries. In my use of the reconstruction validation workflow I found that for some plots we wanted to see if there had been changes in normalisation (for example this might indicate an improvement in efficiency that wouldn't be visible in just a shape comparison). I do, however, understand why the option to normalise the plots is very useful in other scenarios. 

This PR adds the ability to turn the normalisation on and off via environmental variables that will be set from the workflow's config file in `lar_ci`. This allows this parameter to be different between different modules in the workflow (i.e. we can pick and chose). It does not allow picking and choosing at a plot-by-plot level, this would require further work.

I've tested and use this using a separate [branch](https://github.com/SBNSoftware/sbnci/tree/feature/hlay_no_plot_normalisations) that hard-coded the normalisation to be off. I have also tested this branch with the added flexibility on a test run of the reconstruction [validation](https://dbweb9.fnal.gov:8443/TestCI/app/ns:SBND/build_detail/phase_details?build_id=sbnd_ci/6369&platform=Linux%203.10.0-1160.21.1.el7.x86_64&phase=ci_validation&buildtype=slf7%20e19:prof). As you can see the `pfpvalidation`, `pfpslicevalidation` and `pandorashower` modules all had the normalisation turned off whilst the `recoeff` module (muon & proton folders) had the normalisation turned on.

I've requested a review from Vito only as this PR is purely to do with the plotting machinery and not the physics modules. If needed @absolution1 can confirm the physics motivation for this feature (I hope!).