### PR TITLE
Feature/chilgenb conditional cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,28 @@ find_ups_product( eigen )
 find_ups_product( larreco )
 
 find_ups_product( sbnobj )
-find_ups_product( sbndcode )
+
+execute_process(
+  COMMAND bash -c "ups list -aK+ sbndcode | wc -l"
+  OUTPUT_VARIABLE nsbnd
+)
+
+execute_process(
+  COMMAND bash -c "ups list -aK+ icaruscode | wc -l"
+  OUTPUT_VARIABLE nicarus
+)
+
+if(nsbnd GREATER 0)
+  find_ups_product( sbndcode )
+endif()
+
+if(nicarus GREATER 0)
+  find_ups_product( icaruscode )
+endif()
+
+if(nsbnd EQUAL 0 AND nicaruscode EQUAL 0)
+message("neither sbndcode nor icarus code found in UPS!")
+endif()
 
 # macros for dictionary and simple_plugin
 include(ArtDictionary)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,13 @@ find_ups_product( larreco )
 
 find_ups_product( sbnobj )
 
+# mrbsetenv reads from ups/product_deps and sets up 
+# sbndcode and/or icaruscode if available.
+# check for active instances of each and enforce the 
+# requirement that at least one instance is found.
+# in order to avoid dependency clashes, require
+# that only one instance of sbndcode or icaruscode
+# is active (any cases where both needed?).
 execute_process(
   COMMAND bash -c "ups active | grep sbndcode | wc -l"
   OUTPUT_VARIABLE nsbnd
@@ -93,8 +100,12 @@ execute_process(
   OUTPUT_VARIABLE nicarus
 )
 message(STATUS "found ${nsbnd} and ${nicarus} active instances of sbndcode and icaruscode respectively.")
+
 if(${nsbnd} EQUAL 0 AND ${nicarus} EQUAL 0)
   message(FATAL_ERROR "you must setup a UPS bundle with either icarucode or sbndcode! abort build.")
+endif()
+if(${nsbnd} GREATER 0 AND ${nicarus} GREATER 0)
+  message(FATAL_ERROR "icaruscode and sbndcode are both active - this is not supported. please ensure only one is active.")
 endif()
 
 if(${nsbnd} EQUAL 1)
@@ -106,6 +117,7 @@ if(${nicarus} EQUAL 1)
   message(STATUS "setting up icaruscode")
   find_ups_product( icaruscode )
 endif()
+# done. now on to the normal CMake stuff...
 
 find_ups_boost()
 find_ups_root()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,25 +87,27 @@ find_ups_product( larreco )
 find_ups_product( sbnobj )
 
 execute_process(
-  COMMAND bash -c "ups list -aK+ sbndcode | wc -l"
+  COMMAND bash -c "ups active | grep sbndcode | wc -l"
   OUTPUT_VARIABLE nsbnd
 )
 
 execute_process(
-  COMMAND bash -c "ups list -aK+ icaruscode | wc -l"
+  COMMAND bash -c "ups active | grep icaruscode | wc -l"
   OUTPUT_VARIABLE nicarus
 )
+message(STATUS "found ${nsbnd} and ${nicarus} active instances of sbndcode and icaruscode respectively.")
+if(${nsbnd} EQUAL 0 AND ${nicarus} EQUAL 0)
+  message(FATAL_ERROR "you must setup a UPS bundle with either icarucode or sbndcode! abort build.")
+endif()
 
-if(nsbnd GREATER 0)
+if(${nsbnd} EQUAL 1)
+  message(STATUS "setting up sbndcode")
   find_ups_product( sbndcode )
 endif()
 
-if(nicarus GREATER 0)
+if(${nicarus} EQUAL 1)
+  message(STATUS "setting up icaruscode")
   find_ups_product( icaruscode )
-endif()
-
-if(nsbnd EQUAL 0 AND nicaruscode EQUAL 0)
-message("neither sbndcode nor icarus code found in UPS!")
 endif()
 
 # macros for dictionary and simple_plugin

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -27,8 +27,8 @@ defaultqual e20
 # With "product  version" table below, we now define dependencies
 # Add the dependent product and version
 product          version
-sbndcode            v09_28_05
-## icaruscode       v08_43_00
+sbndcode         v09_28_05 - optional # these are optional in the sense that at least one is required
+icaruscode       v09_28_05 - optional # but not both, though both is supported
 
 # list products required ONLY for the build
 # any products here must NOT have qualifiers
@@ -38,14 +38,9 @@ cetbuildtools v7_17_01 - only_for_build
 
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
 # Make the table by adding columns before "notes". 
-
-qualifier     sbndcode     notes
-e20:debug     e20:debug    -nq-
-e20:prof      e20:prof     -nq-
-
-## qualifier     sbndcode    icaruscode   notes
-## e19:debug     e19:debug   e19:debug    -nq-
-## e19:prof      e19:prof    e19:prof     -nq-
+qualifier     sbndcode    icaruscode   notes
+e20:debug     e20:debug   e20:debug    -nq-
+e20:prof      e20:prof    e20:prof     -nq-
 
 
 table_fragment_begin


### PR DESCRIPTION
Make sbndcode and icaruscode both optional dependencies but require that CMake finds one active instance (following the mrbsetenv step). In order to avoid clashing dependencies, do not permit both icaruscode and sbndcode to be active simultaneously.