### PR TITLE
Improve bin/check_proxy.sh

### DIFF
--- a/bin/check_proxy.sh
+++ b/bin/check_proxy.sh
@@ -5,7 +5,7 @@ function get_proxy() {
   [ ${expName} ] || source sbnci_setcodename.sh
 
   echo "getting ${expName} analysis proxy"
-  kx509 --minhours 24 #check cert has enough time left
+  cigetcert -s fifebatch.fnal.gov --minhours 24 # check we have a valid cert on myproxy and local cert has enough time left
 
   voms-proxy-info -exists -vo -valid 24:00 > /dev/null || 
       voms-proxy-init -noregen -rfc -voms "fermilab:/fermilab/${expName}/Role=Analysis" --valid 200:00
@@ -14,11 +14,10 @@ function get_proxy() {
 
 function warn_proxy() {
   echo "no valid proxy found! you must first run 'source get_proxy.sh'"
-  exit 1
+  return 1
 }
 
 function check_proxy() {
   echo "checking proxy"
   voms-proxy-info -exists -vo -valid 24:00 || warn_proxy # check if we already have a proxy and it will last long enough
-  cigetcert -s fifebatch.fnal.gov # check we have a valid proxy on myproxy server
 }


### PR DESCRIPTION
This PR has improvements in checking X509 cert validity. 
in get_proxy() combines cigetcert and k509 calls,
this to check we have valid cert on MyProxy server and that the local cert has enough lifetime.
Also in warn_proxy() this replaces `exit 1` with `return 1`,  here the `exit 1` call would cause a logout.